### PR TITLE
Convert configuration from JSON to JSONC

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ print the token and instructions. Copy the token for the next step.
 
 ### 3. Create a config (on host)
 
-Create `~/.config/lima-escape/config.json` on your **host** with allow/deny
+Create `~/.config/lima-escape/config.jsonc` on your **host** with allow/deny
 rules scoped by directory:
 
 ```json
@@ -157,7 +157,7 @@ lima-escape --help     # full setup reference
 
 ## Security
 
-1. **Token auth**: clients must present a token from `config.json` — without it,
+1. **Token auth**: clients must present a token from `config.jsonc` — without it,
    exec requests are rejected
 2. **Allowlist**: only commands matching token-based patterns in config execute
 3. **No shell**: always `Deno.Command` with argv array, never `sh -c`

--- a/config.example.jsonc
+++ b/config.example.jsonc
@@ -1,6 +1,8 @@
 {
+  // List of authentication tokens allowed to connect to the server
   "tokens": [],
   "allow": {
+    // "*" matches any directory
     "*": [
       "gh pr view *",
       "gh pr list *",
@@ -19,6 +21,7 @@
     "*": [
       "git push -f"
     ],
+    // Specific paths take precedence
     "/home/user/prod-infra": [
       "git *"
     ]

--- a/config.ts
+++ b/config.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { parse } from "@std/jsonc";
 import type { Pattern } from "./match.ts";
 
 export interface Config {
@@ -10,7 +11,14 @@ export interface Config {
 function configPath(): string {
   const home = Deno.env.get("HOME");
   if (!home) throw new Error("HOME environment variable not set");
-  return join(home, ".config", "lima-escape", "config.json");
+  const base = join(home, ".config", "lima-escape");
+  try {
+    const p = join(base, "config.jsonc");
+    Deno.statSync(p);
+    return p;
+  } catch {
+    return join(base, "config.json");
+  }
 }
 
 /** Validate a single pattern: string or array of (string | string[]). */
@@ -59,7 +67,7 @@ export function loadConfig(path?: string): Config {
     throw e;
   }
 
-  const raw = JSON.parse(text);
+  const raw = parse(text) as any;
 
   validateRuleSet(raw.allow, "allow");
   if (raw.deny !== undefined) {
@@ -85,7 +93,7 @@ export function loadConfig(path?: string): Config {
 export function loadTokens(path?: string): string[] {
   const p = path ?? configPath();
   try {
-    const raw = JSON.parse(Deno.readTextFileSync(p));
+    const raw = parse(Deno.readTextFileSync(p)) as any;
     if (Array.isArray(raw.tokens)) return raw.tokens;
     return [];
   } catch {

--- a/config_test.ts
+++ b/config_test.ts
@@ -1,0 +1,69 @@
+import { assertEquals } from "@std/assert";
+import { loadConfig } from "./config.ts";
+
+Deno.test("loadConfig parses JSONC with comments", () => {
+  const tempDir = Deno.makeTempDirSync();
+  const configPath = tempDir + "/config.jsonc";
+  const configContent = `{
+    // This is a comment
+    "allow": {
+      "*": ["git status"]
+    },
+    /* This is a
+       multi-line comment */
+    "tokens": ["test-token"]
+  }`;
+  Deno.writeTextFileSync(configPath, configContent);
+
+  const config = loadConfig(configPath);
+  assertEquals(config.allow["*"], ["git status"]);
+  assertEquals(config.tokens, ["test-token"]);
+
+  Deno.removeSync(tempDir, { recursive: true });
+});
+
+Deno.test("loadConfig falls back to .json if .jsonc is missing", () => {
+  const home = Deno.makeTempDirSync();
+  const originalHome = Deno.env.get("HOME");
+  Deno.env.set("HOME", home);
+
+  try {
+    const configDir = home + "/.config/lima-escape";
+    Deno.mkdirSync(configDir, { recursive: true });
+
+    const configPath = configDir + "/config.json";
+    const configContent = `{"allow": {"*": ["git status"]}}`;
+    Deno.writeTextFileSync(configPath, configContent);
+
+    const config = loadConfig();
+    assertEquals(config.allow["*"], ["git status"]);
+  } finally {
+    if (originalHome) Deno.env.set("HOME", originalHome);
+    else Deno.env.delete("HOME");
+    Deno.removeSync(home, { recursive: true });
+  }
+});
+
+Deno.test("loadConfig prefers .jsonc if both exist", () => {
+  const home = Deno.makeTempDirSync();
+  const originalHome = Deno.env.get("HOME");
+  Deno.env.set("HOME", home);
+
+  try {
+    const configDir = home + "/.config/lima-escape";
+    Deno.mkdirSync(configDir, { recursive: true });
+
+    const jsonPath = configDir + "/config.json";
+    Deno.writeTextFileSync(jsonPath, `{"allow": {"*": ["json"]}}`);
+
+    const jsoncPath = configDir + "/config.jsonc";
+    Deno.writeTextFileSync(jsoncPath, `{"allow": {"*": ["jsonc"]}}`);
+
+    const config = loadConfig();
+    assertEquals(config.allow["*"], ["jsonc"]);
+  } finally {
+    if (originalHome) Deno.env.set("HOME", originalHome);
+    else Deno.env.delete("HOME");
+    Deno.removeSync(home, { recursive: true });
+  }
+});

--- a/deno.json
+++ b/deno.json
@@ -6,6 +6,7 @@
   "imports": {
     "@jlarky/gha-ts": "jsr:@jlarky/gha-ts@^0.2.1",
     "@std/assert": "jsr:@std/assert@1",
+    "@std/jsonc": "jsr:@std/jsonc@^1.0.1",
     "@std/yaml": "jsr:@std/yaml@^1.0.12"
   },
   "test": {

--- a/deno.lock
+++ b/deno.lock
@@ -4,6 +4,8 @@
     "jsr:@jlarky/gha-ts@~0.2.1": "0.2.1",
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/json@^1.0.2": "1.0.3",
+    "jsr:@std/jsonc@^1.0.1": "1.0.2",
     "jsr:@std/yaml@*": "1.0.12",
     "jsr:@std/yaml@^1.0.12": "1.0.12"
   },
@@ -20,6 +22,15 @@
     "@std/internal@1.0.12": {
       "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
     },
+    "@std/json@1.0.3": {
+      "integrity": "97d5710996293a027b7aa5f0d1f4fa29f246f269e6b5597e08807613f37d426c"
+    },
+    "@std/jsonc@1.0.2": {
+      "integrity": "909605dae3af22bd75b1cbda8d64a32cf1fd2cf6efa3f9e224aba6d22c0f44c7",
+      "dependencies": [
+        "jsr:@std/json"
+      ]
+    },
     "@std/yaml@1.0.12": {
       "integrity": "7deabca4545bcedd07c5f69ea53acea71b8b4c67562f224e17b90d75944cb20c"
     }
@@ -28,6 +39,7 @@
     "dependencies": [
       "jsr:@jlarky/gha-ts@~0.2.1",
       "jsr:@std/assert@1",
+      "jsr:@std/jsonc@^1.0.1",
       "jsr:@std/yaml@^1.0.12"
     ]
   }

--- a/main.ts
+++ b/main.ts
@@ -72,7 +72,7 @@ Setup:
 
      ${cmd}
 
-  5. Create a config file at ~/.config/lima-escape/config.json with allow/deny
+  5. Create a config file at ~/.config/lima-escape/config.jsonc with allow/deny
      rules scoped by directory, e.g.:
 
      {
@@ -166,7 +166,7 @@ Learn more at:
 For LLM agents:
   If a command is denied, ask the user to run these on the host machine:
 
-  1. Edit ~/.config/lima-escape/config.json. Current config:
+  1. Edit ~/.config/lima-escape/config.jsonc. Current config:
      ${configJson.split("\n").join("\n     ")}
 
      Keys are directory patterns ("*" = any dir). Add your pattern to the
@@ -207,7 +207,7 @@ For LLM agents:
     Deno.writeTextFileSync(tokenPath(), token + "\n", { mode: 0o600 });
     console.log(`Token saved to ${tokenPath()}\n`);
     console.log(
-      `Add this token to your host config (~/.config/lima-escape/config.json):`,
+      `Add this token to your host config (~/.config/lima-escape/config.jsonc):`,
     );
     console.log(`\n  "tokens": ["${token}"]`);
     console.log(


### PR DESCRIPTION
Converted the configuration format from JSON to JSONC for the `lima-escape` project, allowing users to include comments in their configuration. This change also maintains backward compatibility by falling back to `config.json` if `config.jsonc` is not found. New tests have been added to verify the JSONC parsing and the fallback logic.

---
*PR created automatically by Jules for task [1380209642862726196](https://jules.google.com/task/1380209642862726196) started by @JLarky*