### PR TITLE
Migrate to JSR with automatic publishing

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -26,3 +26,19 @@ jobs:
         run: deno fmt --check
       - name: Test
         run: deno test --allow-net --allow-run --allow-read --allow-env
+  publish:
+    runs-on: ubuntu-latest
+    needs:
+      - test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - name: Publish to JSR
+        run: deno publish

--- a/.github/workflows/ci.main.ts
+++ b/.github/workflows/ci.main.ts
@@ -35,6 +35,27 @@ const wf = workflow({
         },
       ],
     },
+    publish: {
+      "runs-on": "ubuntu-latest",
+      needs: ["test"],
+      if: "github.event_name == 'push' && github.ref == 'refs/heads/main'",
+      permissions: {
+        "id-token": "write",
+        contents: "read",
+      },
+      steps: [
+        checkout(),
+        {
+          name: "Setup Deno",
+          uses: "denoland/setup-deno@v2",
+          with: { "deno-version": "v2.x" },
+        },
+        {
+          name: "Publish to JSR",
+          run: "deno publish",
+        },
+      ],
+    },
   },
 });
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cat > ~/.local/bin/lima-escape << 'EOF'
 exec deno run --no-prompt --ignore-env --allow-env=HOME \
   --allow-read=$HOME/.lima-escape-token --allow-write=$HOME/.lima-escape-token \
   --allow-net=host.lima.internal:27332 \
-  jsr:@jlarky/lima-escape "$@"
+  jsr:@jlarky/lima-escape@0.0.1 "$@"
 EOF
 chmod +x ~/.local/bin/lima-escape
 ```
@@ -132,7 +132,7 @@ specificity.
 ### 4. Start the server (on host)
 
 ```bash
-deno run --no-prompt --ignore-env --allow-env=HOME --allow-read=$HOME/.config/lima-escape,$HOME/vm --allow-net=0.0.0.0:27332 --allow-run=gh,git,say jsr:@jlarky/lima-escape/server
+deno run --no-prompt --ignore-env --allow-env=HOME --allow-read=$HOME/.config/lima-escape,$HOME/vm --allow-net=0.0.0.0:27332 --allow-run=gh,git,say jsr:@jlarky/lima-escape@0.0.1/server
 ```
 
 Adjust `--allow-run` to only allow specific commands. Use `--allow-run=*` to

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cat > ~/.local/bin/lima-escape << 'EOF'
 exec deno run --no-prompt --ignore-env --allow-env=HOME \
   --allow-read=$HOME/.lima-escape-token --allow-write=$HOME/.lima-escape-token \
   --allow-net=host.lima.internal:27332 \
-  https://raw.githubusercontent.com/JLarky/lima-escape/refs/heads/main/main.ts "$@"
+  jsr:@jlarky/lima-escape "$@"
 EOF
 chmod +x ~/.local/bin/lima-escape
 ```
@@ -132,7 +132,7 @@ specificity.
 ### 4. Start the server (on host)
 
 ```bash
-deno run --no-prompt --ignore-env --allow-env=HOME --allow-read=$HOME/.config/lima-escape,$HOME/vm --allow-net=0.0.0.0:27332 --allow-run=gh,git,say https://raw.githubusercontent.com/JLarky/lima-escape/refs/heads/main/server.ts
+deno run --no-prompt --ignore-env --allow-env=HOME --allow-read=$HOME/.config/lima-escape,$HOME/vm --allow-net=0.0.0.0:27332 --allow-run=gh,git,say jsr:@jlarky/lima-escape/server
 ```
 
 Adjust `--allow-run` to only allow specific commands. Use `--allow-run=*` to

--- a/deno.json
+++ b/deno.json
@@ -1,4 +1,10 @@
 {
+  "name": "@jlarky/lima-escape",
+  "version": "0.0.1",
+  "exports": {
+    ".": "./main.ts",
+    "./server": "./server.ts"
+  },
   "tasks": {
     "server": "./server.ts",
     "client": "./main.ts"

--- a/main.ts
+++ b/main.ts
@@ -21,7 +21,7 @@ function loadClientToken(): string | null {
 
 if (import.meta.main) {
   const cmd =
-    `deno run --no-prompt --ignore-env --allow-env=HOME --allow-read=$HOME/.config/lima-escape,$HOME/vm --allow-net=0.0.0.0:27332 --allow-run=gh,git,say jsr:@jlarky/lima-escape/server`;
+    `deno run --no-prompt --ignore-env --allow-env=HOME --allow-read=$HOME/.config/lima-escape,$HOME/vm --allow-net=0.0.0.0:27332 --allow-run=gh,git,say jsr:@jlarky/lima-escape@0.0.1/server`;
 
   if (
     Deno.args.length === 0 || Deno.args[0] === "--help" ||
@@ -48,7 +48,7 @@ Setup:
      exec deno run --no-prompt --ignore-env --allow-env=HOME \\
        --allow-read=$HOME/.lima-escape-token --allow-write=$HOME/.lima-escape-token \\
        --allow-net=host.lima.internal:27332 \\
-       jsr:@jlarky/lima-escape "$@"
+       jsr:@jlarky/lima-escape@0.0.1 "$@"
 
      Then: chmod +x ~/.local/bin/lima-escape
 
@@ -151,7 +151,7 @@ Learn more at:
         console.log(`  ${command.padEnd(12)} ${state}`);
       }
       const allowRunKeys = Object.keys(status.allowRun);
-      const serverUrl = `jsr:@jlarky/lima-escape/server`;
+      const serverUrl = `jsr:@jlarky/lima-escape@0.0.1/server`;
       const serverCmd = (cmds: string[]) =>
         `deno run --no-prompt --ignore-env --allow-env=HOME --allow-read=$HOME/.config/lima-escape,$HOME/vm --allow-net=0.0.0.0:${port} --allow-run=${
           cmds.join(",")

--- a/main.ts
+++ b/main.ts
@@ -21,7 +21,7 @@ function loadClientToken(): string | null {
 
 if (import.meta.main) {
   const cmd =
-    `deno run --no-prompt --ignore-env --allow-env=HOME --allow-read=$HOME/.config/lima-escape,$HOME/vm --allow-net=0.0.0.0:27332 --allow-run=gh,git,say https://raw.githubusercontent.com/JLarky/lima-escape/refs/heads/main/server.ts`;
+    `deno run --no-prompt --ignore-env --allow-env=HOME --allow-read=$HOME/.config/lima-escape,$HOME/vm --allow-net=0.0.0.0:27332 --allow-run=gh,git,say jsr:@jlarky/lima-escape/server`;
 
   if (
     Deno.args.length === 0 || Deno.args[0] === "--help" ||
@@ -48,7 +48,7 @@ Setup:
      exec deno run --no-prompt --ignore-env --allow-env=HOME \\
        --allow-read=$HOME/.lima-escape-token --allow-write=$HOME/.lima-escape-token \\
        --allow-net=host.lima.internal:27332 \\
-       https://raw.githubusercontent.com/JLarky/lima-escape/refs/heads/main/main.ts "$@"
+       jsr:@jlarky/lima-escape "$@"
 
      Then: chmod +x ~/.local/bin/lima-escape
 
@@ -151,8 +151,7 @@ Learn more at:
         console.log(`  ${command.padEnd(12)} ${state}`);
       }
       const allowRunKeys = Object.keys(status.allowRun);
-      const serverUrl =
-        `https://raw.githubusercontent.com/JLarky/lima-escape/refs/heads/main/server.ts`;
+      const serverUrl = `jsr:@jlarky/lima-escape/server`;
       const serverCmd = (cmds: string[]) =>
         `deno run --no-prompt --ignore-env --allow-env=HOME --allow-read=$HOME/.config/lima-escape,$HOME/vm --allow-net=0.0.0.0:${port} --allow-run=${
           cmds.join(",")


### PR DESCRIPTION
Migrated the application from raw GitHub HTTPS imports to a JSR-hosted package.

Changes:
- Added JSR metadata and exports to `deno.json`.
- Updated help text and documentation to use `jsr:@jlarky/lima-escape` instead of GitHub URLs.
- Integrated `deno publish` into the GitHub Actions CI pipeline.
- Verified that all tests pass.

Manual Checklist for PR Description:
- [ ] Create `@jlarky/lima-escape` on [jsr.io](https://jsr.io).
- [ ] Link the `JLarky/lima-escape` GitHub repository to the JSR package.
- [ ] Ensure the first version `0.0.1` is published (will happen on next push to main after linking).

---
*PR created automatically by Jules for task [17047740806954422709](https://jules.google.com/task/17047740806954422709) started by @JLarky*