### PR TITLE
add pathMap support for lima cwd resolution

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -25,4 +25,10 @@ jobs:
       - name: Format check
         run: deno fmt --check
       - name: Test
-        run: deno test --allow-net --allow-run --allow-read --allow-env
+        run: >
+          export TMPDIR="$RUNNER_TEMP/lima-escape-tests"
+
+          mkdir -p "$TMPDIR"
+
+          deno test --allow-net --allow-run --allow-read --allow-env
+          --allow-write="$TMPDIR"

--- a/.github/workflows/ci.main.ts
+++ b/.github/workflows/ci.main.ts
@@ -31,7 +31,11 @@ const wf = workflow({
         { name: "Format check", run: "deno fmt --check" },
         {
           name: "Test",
-          run: "deno test --allow-net --allow-run --allow-read --allow-env",
+          run: lines`
+            export TMPDIR="$RUNNER_TEMP/lima-escape-tests"
+            mkdir -p "$TMPDIR"
+            deno test --allow-net --allow-run --allow-read --allow-env --allow-write="$TMPDIR"
+          `,
         },
       ],
     },

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ rules scoped by directory:
 ```json
 {
   "tokens": ["<paste token from lima-escape --auth>"],
+  "pathMap": {
+    "/home/jlarky.guest/work": "/Users/jlarky/work"
+  },
   "allow": {
     "*": [
       "say *",
@@ -90,6 +93,11 @@ rules scoped by directory:
   }
 }
 ```
+
+`pathMap` is optional. It rewrites a Lima cwd prefix to a host cwd prefix before
+execution. This lets you run commands from a Lima path that does not exist on
+the host, as long as the mapped host path does exist. Allow/deny rules still
+match the original Lima path.
 
 #### Command patterns
 
@@ -129,6 +137,17 @@ Keys in allow/deny objects are directory patterns:
 More specific paths override less specific ones. Deny rules break ties at equal
 specificity.
 
+#### Path mappings
+
+- Keys in `pathMap` are absolute Lima path prefixes
+- Values in `pathMap` are absolute host path prefixes
+- Longest matching prefix wins
+- If the original cwd already exists on the host, it is used as-is
+- If the original cwd does not exist and no mapping matches, the request is
+  rejected
+- If a mapping matches but the translated host path does not exist, the request
+  is rejected
+
 ### 4. Start the server (on host)
 
 ```bash
@@ -164,8 +183,8 @@ lima-escape --help     # full setup reference
 4. **Argv-in, argv-out**: client sends pre-split argv from the OS, server
    executes as argv — no string splitting
 5. **cwd validation**: the server resolves the client-provided working directory
-   with `realPath`, rejecting non-absolute, non-existent, or non-directory
-   paths. This prevents path traversal and fabricated paths.
+   with `realPath`, or translates it through `pathMap` first. It still rejects
+   non-absolute, non-existent, or non-directory execution paths.
 6. **TCP exposure**: server binds to `0.0.0.0` by default — any host on the
    network can connect. Scope with `--allow-net=0.0.0.0:27332` for the listening
    port only

--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,8 @@
 {
   "tokens": [],
+  "pathMap": {
+    "/home/jlarky.guest/work": "/Users/jlarky/work"
+  },
   "allow": {
     "*": [
       "gh pr view *",

--- a/config.ts
+++ b/config.ts
@@ -5,6 +5,7 @@ export interface Config {
   allow: Record<string, Pattern[]>;
   deny?: Record<string, Pattern[]>;
   tokens?: string[];
+  pathMap?: Record<string, string>;
 }
 
 function configPath(): string {
@@ -45,6 +46,28 @@ function validateRuleSet(
   }
 }
 
+function validatePathMap(
+  value: unknown,
+): asserts value is Record<string, string> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(
+      'Invalid config: "pathMap" must be an object mapping VM path prefixes to host path prefixes',
+    );
+  }
+  for (const [vmPath, hostPath] of Object.entries(value)) {
+    if (!vmPath.startsWith("/")) {
+      throw new Error(
+        `Invalid config: "pathMap" key "${vmPath}" must be an absolute path`,
+      );
+    }
+    if (typeof hostPath !== "string" || !hostPath.startsWith("/")) {
+      throw new Error(
+        `Invalid config: "pathMap" key "${vmPath}" must map to an absolute host path string`,
+      );
+    }
+  }
+}
+
 export function loadConfig(path?: string): Config {
   const p = path ?? configPath();
   let text: string;
@@ -65,6 +88,9 @@ export function loadConfig(path?: string): Config {
   if (raw.deny !== undefined) {
     validateRuleSet(raw.deny, "deny");
   }
+  if (raw.pathMap !== undefined) {
+    validatePathMap(raw.pathMap);
+  }
   if (raw.tokens !== undefined) {
     if (
       !Array.isArray(raw.tokens) ||
@@ -77,6 +103,7 @@ export function loadConfig(path?: string): Config {
   return {
     allow: raw.allow,
     ...(raw.deny ? { deny: raw.deny } : {}),
+    ...(raw.pathMap ? { pathMap: raw.pathMap } : {}),
     ...(raw.tokens ? { tokens: raw.tokens } : {}),
   };
 }

--- a/config_test.ts
+++ b/config_test.ts
@@ -1,0 +1,64 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { loadConfig } from "./config.ts";
+
+function writeTempConfig(config: unknown): string {
+  const path = Deno.makeTempFileSync({ suffix: ".json" });
+  Deno.writeTextFileSync(path, JSON.stringify(config));
+  return path;
+}
+
+Deno.test("loadConfig: accepts valid pathMap", () => {
+  const path = writeTempConfig({
+    pathMap: {
+      "/home/jlarky.guest/work": "/Users/jlarky/work",
+    },
+    allow: { "*": ["git status"] },
+  });
+
+  try {
+    const config = loadConfig(path);
+    assertEquals(config.pathMap, {
+      "/home/jlarky.guest/work": "/Users/jlarky/work",
+    });
+  } finally {
+    Deno.removeSync(path);
+  }
+});
+
+Deno.test("loadConfig: rejects relative pathMap keys", () => {
+  const path = writeTempConfig({
+    pathMap: {
+      "home/jlarky.guest/work": "/Users/jlarky/work",
+    },
+    allow: { "*": ["git status"] },
+  });
+
+  try {
+    assertThrows(
+      () => loadConfig(path),
+      Error,
+      '"pathMap" key "home/jlarky.guest/work" must be an absolute path',
+    );
+  } finally {
+    Deno.removeSync(path);
+  }
+});
+
+Deno.test("loadConfig: rejects relative pathMap values", () => {
+  const path = writeTempConfig({
+    pathMap: {
+      "/home/jlarky.guest/work": "Users/jlarky/work",
+    },
+    allow: { "*": ["git status"] },
+  });
+
+  try {
+    assertThrows(
+      () => loadConfig(path),
+      Error,
+      "must map to an absolute host path string",
+    );
+  } finally {
+    Deno.removeSync(path);
+  }
+});

--- a/integration_test.ts
+++ b/integration_test.ts
@@ -1,6 +1,8 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import {
+  getCwdStatus,
   MAX_OUTPUT_SIZE,
+  resolveRequestCwd,
   startClient,
   truncateOutput,
   validateCwd,
@@ -354,4 +356,82 @@ Deno.test("validateCwd: resolves path traversal", async () => {
     // should be normalized — no ".." in resolved path
     assertEquals(result.resolved.includes(".."), false);
   }
+});
+
+Deno.test("resolveRequestCwd: uses existing host cwd as-is", async () => {
+  const result = await resolveRequestCwd("/tmp", {
+    "/tmp": "/does/not/matter",
+  });
+  assertEquals("error" in result, false);
+  if ("logical" in result) {
+    assertEquals(result.logical.startsWith("/"), true);
+    assertEquals(result.execution.startsWith("/"), true);
+  }
+});
+
+Deno.test("resolveRequestCwd: maps nonexistent Lima cwd to host cwd", async () => {
+  const result = await resolveRequestCwd(
+    "/home/jlarky.guest/work/project",
+    {
+      "/home/jlarky.guest/work/project": "/tmp",
+    },
+  );
+  assertEquals("error" in result, false);
+  if ("logical" in result) {
+    assertEquals(result.logical, "/home/jlarky.guest/work/project");
+    assertEquals(result.execution, "/tmp");
+  }
+});
+
+Deno.test("resolveRequestCwd: prefers the most specific path mapping", async () => {
+  const result = await resolveRequestCwd(
+    "/vm/project",
+    {
+      "/vm": "/tmp",
+      "/vm/project": "/var/tmp",
+    },
+  );
+  assertEquals("error" in result, false);
+  if ("logical" in result) {
+    assertEquals(result.execution, "/var/tmp");
+  }
+});
+
+Deno.test("resolveRequestCwd: reports translated host path failures", async () => {
+  const result = await resolveRequestCwd(
+    "/home/jlarky.guest/work/project",
+    {
+      "/home/jlarky.guest/work": "/definitely/not/here",
+    },
+  );
+  assertEquals("error" in result, true);
+  if ("error" in result) {
+    assertStringIncludes(
+      result.error,
+      'mapped to "/definitely/not/here/project"',
+    );
+  }
+});
+
+Deno.test("getCwdStatus: reports mapped current cwd", async () => {
+  const status = await getCwdStatus("/home/jlarky.guest/work/project", {
+    "/home/jlarky.guest/work/project": "/tmp",
+  });
+
+  assertEquals(status.requested, "/home/jlarky.guest/work/project");
+  assertEquals(status.matchCwd, "/home/jlarky.guest/work/project");
+  assertEquals(status.executionCwd, "/tmp");
+  assertEquals(status.mapped, true);
+  assertEquals(status.error, undefined);
+});
+
+Deno.test("getCwdStatus: reports rejected current cwd", async () => {
+  const status = await getCwdStatus("/home/jlarky.guest/work/project", {
+    "/home/jlarky.guest/work": "/definitely/not/here",
+  });
+
+  assertEquals(status.requested, "/home/jlarky.guest/work/project");
+  assertEquals(typeof status.error, "string");
+  assertEquals(status.matchCwd, undefined);
+  assertEquals(status.executionCwd, undefined);
 });

--- a/main.ts
+++ b/main.ts
@@ -77,13 +77,19 @@ Setup:
 
      {
        "tokens": ["<paste token from step 6>"],
+       "pathMap": {
+         "/home/jlarky.guest/work": "/Users/jlarky/work"
+       },
        "allow": { "*": ["gh pr view *", "git status"] },
        "deny": { "/sensitive": ["git *"] }
      }
 
-     Keys are directory patterns. "*" matches any directory; paths use prefix
-     matching (e.g. "/home/user" matches "/home/user/sub"). Command patterns
-     use exact token matching — "gh pr *" means gh + pr + zero or more args.
+     pathMap is optional. It rewrites a Lima cwd prefix to a host cwd prefix
+     before execution. Allow/deny rules still match the Lima path you ran from.
+
+      Keys are directory patterns. "*" matches any directory; paths use prefix
+      matching (e.g. "/home/user" matches "/home/user/sub"). Command patterns
+      use exact token matching - "gh pr *" means gh + pr + zero or more args.
      Deny rules take precedence over allow rules at equal specificity.
 
   6. Authenticate from the VM:
@@ -146,6 +152,24 @@ Learn more at:
           }
         }
       }
+      if (status.pathMap) {
+        console.log("\nPath mappings:");
+        for (const [vmPath, hostPath] of Object.entries(status.pathMap)) {
+          console.log(`  ${vmPath} -> ${hostPath}`);
+        }
+      }
+      if (status.cwdStatus) {
+        console.log("\nCurrent cwd:");
+        console.log(`  requested  ${status.cwdStatus.requested}`);
+        if (status.cwdStatus.error) {
+          console.log(`  rejected   ${status.cwdStatus.error}`);
+        } else if (status.cwdStatus.mapped) {
+          console.log(`  matched    ${status.cwdStatus.matchCwd}`);
+          console.log(`  executes   ${status.cwdStatus.executionCwd}`);
+        } else {
+          console.log(`  executes   ${status.cwdStatus.executionCwd}`);
+        }
+      }
       console.log("\nExecutable commands (--allow-run):");
       for (const [command, state] of Object.entries(status.allowRun)) {
         console.log(`  ${command.padEnd(12)} ${state}`);
@@ -158,7 +182,11 @@ Learn more at:
           cmds.join(",")
         } ${serverUrl}`;
       const configJson = JSON.stringify(
-        { allow: status.allow, ...(status.deny ? { deny: status.deny } : {}) },
+        {
+          ...(status.pathMap ? { pathMap: status.pathMap } : {}),
+          allow: status.allow,
+          ...(status.deny ? { deny: status.deny } : {}),
+        },
         null,
         2,
       );

--- a/server.ts
+++ b/server.ts
@@ -28,6 +28,7 @@ function checkToken(token: string): boolean {
 await startServer({
   allow: config.allow,
   deny: config.deny,
+  pathMap: config.pathMap,
   isAllowed,
   checkToken,
 });

--- a/shared.ts
+++ b/shared.ts
@@ -16,8 +16,18 @@ export interface Request {
 export interface StatusInfo {
   allow: Record<string, Pattern[]>;
   deny?: Record<string, Pattern[]>;
+  pathMap?: Record<string, string>;
+  cwdStatus?: CwdStatus;
   allowRun: Record<string, string>;
   pid?: number;
+}
+
+export interface CwdStatus {
+  requested: string;
+  matchCwd?: string;
+  executionCwd?: string;
+  mapped?: boolean;
+  error?: string;
 }
 
 export interface Response {
@@ -32,9 +42,34 @@ import type { AllowResult, Pattern, Rules } from "./match.ts";
 export interface ServerOptions {
   allow: Record<string, Pattern[]>;
   deny?: Record<string, Pattern[]>;
+  pathMap?: Record<string, string>;
   isAllowed: (argv: string[], cwd: string, rules: Rules) => AllowResult;
   port?: number;
   checkToken?: (token: string) => boolean;
+}
+
+function pathSpecificity(path: string): number {
+  return path.split("/").filter(Boolean).length;
+}
+
+function translatePath(path: string, pathMap?: Record<string, string>): string {
+  if (!pathMap || !path.startsWith("/")) return path;
+
+  let bestMatch: [string, string] | undefined;
+  for (const entry of Object.entries(pathMap)) {
+    const [vmPrefix] = entry;
+    if (path !== vmPrefix && !path.startsWith(vmPrefix + "/")) continue;
+    if (
+      !bestMatch || pathSpecificity(vmPrefix) > pathSpecificity(bestMatch[0])
+    ) {
+      bestMatch = entry;
+    }
+  }
+
+  if (!bestMatch) return path;
+  const [vmPrefix, hostPrefix] = bestMatch;
+  const suffix = path.slice(vmPrefix.length);
+  return hostPrefix + suffix;
 }
 
 export function truncateOutput(
@@ -66,6 +101,61 @@ export async function validateCwd(
   } catch {
     return { error: `cwd does not exist on host: "${cwd}"` };
   }
+}
+
+export async function resolveRequestCwd(
+  requestedCwd: string,
+  pathMap?: Record<string, string>,
+): Promise<
+  | { logical: string; execution: string }
+  | { error: string }
+> {
+  const logicalResult = await validateCwd(requestedCwd).catch(() => ({
+    error: `cwd does not exist on host: "${requestedCwd}"`,
+  }));
+  if ("resolved" in logicalResult) {
+    return {
+      logical: logicalResult.resolved,
+      execution: logicalResult.resolved,
+    };
+  }
+
+  const translatedCwd = translatePath(requestedCwd, pathMap);
+  if (translatedCwd === requestedCwd) {
+    return { error: logicalResult.error };
+  }
+
+  const translatedResult = await validateCwd(translatedCwd);
+  if ("error" in translatedResult) {
+    return {
+      error:
+        `${logicalResult.error}; mapped to "${translatedCwd}" but ${translatedResult.error}`,
+    };
+  }
+
+  return {
+    logical: requestedCwd,
+    execution: translatedResult.resolved,
+  };
+}
+
+export async function getCwdStatus(
+  requestedCwd: string,
+  pathMap?: Record<string, string>,
+): Promise<CwdStatus> {
+  const cwdResult = await resolveRequestCwd(requestedCwd, pathMap);
+  if ("error" in cwdResult) {
+    return {
+      requested: requestedCwd,
+      error: cwdResult.error,
+    };
+  }
+  return {
+    requested: requestedCwd,
+    matchCwd: cwdResult.logical,
+    executionCwd: cwdResult.execution,
+    mapped: cwdResult.logical !== cwdResult.execution,
+  };
 }
 
 async function executeCommand(argv: string[], cwd: string): Promise<Response> {
@@ -134,6 +224,8 @@ async function handleConnection(conn: Deno.Conn, opts: ServerOptions) {
       const status: StatusInfo = {
         allow: opts.allow,
         ...(opts.deny ? { deny: opts.deny } : {}),
+        ...(opts.pathMap ? { pathMap: opts.pathMap } : {}),
+        cwdStatus: await getCwdStatus(req.cwd, opts.pathMap),
         allowRun,
         ...(authenticated ? { pid: Deno.pid } : {}),
       };
@@ -150,7 +242,7 @@ async function handleConnection(conn: Deno.Conn, opts: ServerOptions) {
         };
         console.log("rejected: invalid or missing auth token");
       } else {
-        const cwdResult = await validateCwd(req.cwd);
+        const cwdResult = await resolveRequestCwd(req.cwd, opts.pathMap);
         if ("error" in cwdResult) {
           res = {
             code: 1,
@@ -160,9 +252,10 @@ async function handleConnection(conn: Deno.Conn, opts: ServerOptions) {
           };
           console.log("rejected: invalid cwd -", cwdResult.error);
         } else {
-          const cwd = cwdResult.resolved;
+          const matchCwd = cwdResult.logical;
+          const executionCwd = cwdResult.execution;
           const rules: Rules = { allow: opts.allow, deny: opts.deny };
-          const result = opts.isAllowed(req.argv, cwd, rules);
+          const result = opts.isAllowed(req.argv, matchCwd, rules);
           if (!result.allowed) {
             const cmd = req.argv.join(" ");
             const hint = result.hint ? `\nhint: ${result.hint}` : "";
@@ -176,9 +269,16 @@ async function handleConnection(conn: Deno.Conn, opts: ServerOptions) {
             console.log("denied:", cmd, "-", result.reason);
           } else {
             const cmd = req.argv.join(" ");
-            console.log("executing:", cmd, "in", cwd);
+            console.log(
+              "executing:",
+              cmd,
+              "for requested cwd",
+              matchCwd,
+              "in",
+              executionCwd,
+            );
             try {
-              res = await executeCommand(req.argv, cwd);
+              res = await executeCommand(req.argv, executionCwd);
             } catch (e) {
               res = {
                 code: 1,


### PR DESCRIPTION
## Summary
- add optional `pathMap` config so Lima-only cwd prefixes can resolve to host directories before execution
- keep allow/deny matching scoped to the original VM cwd and show the resolved cwd in `lima-escape --status`
- add config and integration tests covering path mapping, validation, and current-cwd status reporting

## Testing
- mise exec deno -- deno fmt
- mise exec deno -- deno test -A