### PR TITLE
Use jsr:@jlarky/lima-escape in setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cat > ~/.local/bin/lima-escape << 'EOF'
 exec deno run --no-prompt --ignore-env --allow-env=HOME \
   --allow-read=$HOME/.lima-escape-token --allow-write=$HOME/.lima-escape-token \
   --allow-net=host.lima.internal:27332 \
-  https://raw.githubusercontent.com/JLarky/lima-escape/refs/heads/main/main.ts "$@"
+  jsr:@jlarky/lima-escape/client "$@"
 EOF
 chmod +x ~/.local/bin/lima-escape
 ```
@@ -151,7 +151,7 @@ specificity.
 ### 4. Start the server (on host)
 
 ```bash
-deno run --no-prompt --ignore-env --allow-env=HOME --allow-read=$HOME/.config/lima-escape,$HOME/vm --allow-net=0.0.0.0:27332 --allow-run=gh,git,say https://raw.githubusercontent.com/JLarky/lima-escape/refs/heads/main/server.ts
+deno run --no-prompt --ignore-env --allow-env=HOME --allow-read=$HOME/.config/lima-escape,$HOME/vm --allow-net=0.0.0.0:27332 --allow-run=gh,git,say jsr:@jlarky/lima-escape
 ```
 
 Adjust `--allow-run` to only allow specific commands. Use `--allow-run=*` to

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@jlarky/lima-escape",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "MIT",
   "exports": {
     ".": "./server.ts",

--- a/main.ts
+++ b/main.ts
@@ -21,7 +21,7 @@ function loadClientToken(): string | null {
 
 if (import.meta.main) {
   const cmd =
-    `deno run --no-prompt --ignore-env --allow-env=HOME --allow-read=$HOME/.config/lima-escape,$HOME/vm --allow-net=0.0.0.0:27332 --allow-run=gh,git,say https://raw.githubusercontent.com/JLarky/lima-escape/refs/heads/main/server.ts`;
+    `deno run --no-prompt --ignore-env --allow-env=HOME --allow-read=$HOME/.config/lima-escape,$HOME/vm --allow-net=0.0.0.0:27332 --allow-run=gh,git,say jsr:@jlarky/lima-escape`;
 
   if (
     Deno.args.length === 0 || Deno.args[0] === "--help" ||
@@ -48,7 +48,7 @@ Setup:
      exec deno run --no-prompt --ignore-env --allow-env=HOME \\
        --allow-read=$HOME/.lima-escape-token --allow-write=$HOME/.lima-escape-token \\
        --allow-net=host.lima.internal:27332 \\
-       https://raw.githubusercontent.com/JLarky/lima-escape/refs/heads/main/main.ts "$@"
+       jsr:@jlarky/lima-escape/client "$@"
 
      Then: chmod +x ~/.local/bin/lima-escape
 
@@ -175,8 +175,7 @@ Learn more at:
         console.log(`  ${command.padEnd(12)} ${state}`);
       }
       const allowRunKeys = Object.keys(status.allowRun);
-      const serverUrl =
-        `https://raw.githubusercontent.com/JLarky/lima-escape/refs/heads/main/server.ts`;
+      const serverUrl = `jsr:@jlarky/lima-escape`;
       const serverCmd = (cmds: string[]) =>
         `deno run --no-prompt --ignore-env --allow-env=HOME --allow-read=$HOME/.config/lima-escape,$HOME/vm --allow-net=0.0.0.0:${port} --allow-run=${
           cmds.join(",")


### PR DESCRIPTION
## Summary
Now that `@jlarky/lima-escape` is published on JSR, switch all five raw `https://raw.githubusercontent.com/.../main.ts|server.ts` references in the docs and CLI output to the JSR package. Versionless (no `@^0.0.1`) so users always pull the latest publish; pinning is left to whoever runs the install command.

| Spot | Before | After |
|---|---|---|
| `README.md` setup #1 (client install) | raw `main.ts` | `jsr:@jlarky/lima-escape/client` |
| `README.md` setup #4 (server start) | raw `server.ts` | `jsr:@jlarky/lima-escape` |
| `main.ts` `cmd` (shown when invoked with no args) | raw `server.ts` | `jsr:@jlarky/lima-escape` |
| `main.ts` help-text install snippet | raw `main.ts` | `jsr:@jlarky/lima-escape/client` |
| `main.ts` `--status` `serverUrl` | raw `server.ts` | `jsr:@jlarky/lima-escape` |

The default JSR export `.` is `server.ts`, so the server uses the bare specifier and the client uses the `/client` subpath.

## Test plan
- [x] `deno run jsr:@jlarky/lima-escape/client --help` prints the help text
- [x] `deno check jsr:@jlarky/lima-escape` exits 0
- [x] Patched `./main.ts --status` (against a down server) now prints the JSR-based start command
- [x] `deno fmt --check` and `deno lint` clean
- [ ] After merge, run the README setup end-to-end in a Lima VM (auth → server → exec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)