### PR TITLE
Distinguish PermissionDenied from missing cwd in validation error

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@jlarky/lima-escape",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "license": "MIT",
   "exports": {
     ".": "./server.ts",

--- a/shared.ts
+++ b/shared.ts
@@ -98,7 +98,13 @@ export async function validateCwd(
       return { error: `cwd is not a directory: "${cwd}"` };
     }
     return { resolved };
-  } catch {
+  } catch (e) {
+    if (e instanceof Deno.errors.PermissionDenied) {
+      return {
+        error:
+          `cwd not readable on host (server needs --allow-read=${cwd}): "${cwd}"`,
+      };
+    }
     return { error: `cwd does not exist on host: "${cwd}"` };
   }
 }


### PR DESCRIPTION
## Why

\`validateCwd\` currently swallows every error from \`Deno.realPath\` with a bare \`catch {}\` and reports the same message: \`cwd does not exist on host\`. That hides the most common real cause: the server's \`--allow-read\` scope doesn't cover the host path.

This bites hardest with the new \`pathMap\` feature: the translated host path can exist *and* be a directory, but \`realPath\` still throws \`PermissionDenied\` because the server was started with a narrower \`--allow-read\` than the mapped path. The user sees:

> invalid cwd: cwd does not exist on host: \"/home/user.guest/work/foo\"; mapped to \"/Users/user/work/foo\" but cwd does not exist on host: \"/Users/user/work/foo\"

…even though \`/Users/user/work/foo\` exists. Real fix is to extend \`--allow-read\`, but the misleading error makes that hard to discover.

## What

Catch \`Deno.errors.PermissionDenied\` separately and return a message that names the path that needs to be added to \`--allow-read\`. Other errors (NotFound, etc.) keep the existing \"does not exist\" wording.

## Testing

- \`mise exec deno -- deno fmt --check\`
- \`mise exec deno -- deno test --allow-net --allow-run --allow-read --allow-env --allow-write=\$TMPDIR\` — 76 passed