### PR TITLE
Catch Deno 2's NotCapable error class for cwd permission checks

### DIFF
--- a/integration_test.ts
+++ b/integration_test.ts
@@ -358,6 +358,19 @@ Deno.test("validateCwd: resolves path traversal", async () => {
   }
 });
 
+Deno.test({
+  name: "validateCwd: distinguishes runtime permission error from missing path",
+  permissions: { read: ["/tmp"] },
+  async fn() {
+    const result = await validateCwd("/usr");
+    assertEquals("error" in result, true);
+    if ("error" in result) {
+      assertStringIncludes(result.error, "not readable");
+      assertStringIncludes(result.error, "--allow-read=/usr");
+    }
+  },
+});
+
 Deno.test("resolveRequestCwd: uses existing host cwd as-is", async () => {
   const result = await resolveRequestCwd("/tmp", {
     "/tmp": "/does/not/matter",

--- a/shared.ts
+++ b/shared.ts
@@ -99,7 +99,8 @@ export async function validateCwd(
     }
     return { resolved };
   } catch (e) {
-    if (e instanceof Deno.errors.PermissionDenied) {
+    const name = (e as Error)?.name;
+    if (name === "NotCapable" || name === "PermissionDenied") {
       return {
         error:
           `cwd not readable on host (server needs --allow-read=${cwd}): "${cwd}"`,


### PR DESCRIPTION
Follow-up to #24. v0.0.3 still hits the same misleading error in practice:

> rejected: invalid cwd - cwd does not exist on host: \"/home/user.guest/work/iq-flow\"; mapped to \"/Users/user/work/iq-flow\" but cwd does not exist on host: \"/Users/user/work/iq-flow\"

…even though the mapped path exists.

## Why

#24 caught \`Deno.errors.PermissionDenied\`, but Deno 2 throws \`Deno.errors.NotCapable\` for runtime sandbox violations (\`--allow-read\` scope). \`PermissionDenied\` is now reserved for OS-level permission errors. Confirmed via probe:

\`\`\`
name: NotCapable
constructor: NotCapable
isPermissionDenied: false
isNotCapable: true
\`\`\`

So the v0.0.3 catch falls through to the generic \"does not exist\" branch and the user is none the wiser.

## What

- Check \`(e as Error)?.name === \"NotCapable\" || \"PermissionDenied\"\` instead of \`instanceof\`. Avoids hard-depending on \`Deno.errors.NotCapable\` (which only exists in newer Deno versions) while still handling both classes.
- Add a regression test using \`Deno.test\`'s per-test \`permissions\` option to narrow read scope to \`/tmp\`, then validate \`/usr\`. The new test fails against v0.0.3 and passes with this fix.

## Testing

- \`mise exec deno -- deno test --allow-net --allow-run --allow-read --allow-env --allow-write=\$TMPDIR\` — 77 passed
- \`mise exec deno -- deno fmt --check\`