### PR TITLE
Bump @jlarky/gha-ts to ^0.2.2 (actions/checkout@v5)

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install Deno
         uses: denoland/setup-deno@v2
         with:
@@ -23,7 +23,7 @@ jobs:
   test:
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:

--- a/.github/workflows/create-release.generated.yml
+++ b/.github/workflows/create-release.generated.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Get version from deno.json
         id: get_version
         run: echo "version=$(jq -r .version deno.json)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish.generated.yml
+++ b/.github/workflows/publish.generated.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install Deno
         uses: denoland/setup-deno@v2
         with:

--- a/deno.json
+++ b/deno.json
@@ -19,7 +19,7 @@
     "client": "./main.ts"
   },
   "imports": {
-    "@jlarky/gha-ts": "jsr:@jlarky/gha-ts@^0.2.1",
+    "@jlarky/gha-ts": "jsr:@jlarky/gha-ts@^0.2.2",
     "@std/assert": "jsr:@std/assert@1",
     "@std/yaml": "jsr:@std/yaml@^1.0.12"
   },

--- a/deno.lock
+++ b/deno.lock
@@ -1,15 +1,15 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@jlarky/gha-ts@~0.2.1": "0.2.1",
+    "jsr:@jlarky/gha-ts@~0.2.2": "0.2.2",
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/internal@^1.0.12": "1.0.12",
     "jsr:@std/yaml@*": "1.0.12",
-    "jsr:@std/yaml@^1.0.12": "1.0.12"
+    "jsr:@std/yaml@^1.0.12": "1.1.0"
   },
   "jsr": {
-    "@jlarky/gha-ts@0.2.1": {
-      "integrity": "98957a4267375402305c64f35255d6b9f87852292b8626aff54e391c8a8a8060"
+    "@jlarky/gha-ts@0.2.2": {
+      "integrity": "89f65dfb2f15ee868ce90bdb69c7ce47cfbc8c42e38f5ec1b04eee5e7ecabdb9"
     },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
@@ -22,11 +22,14 @@
     },
     "@std/yaml@1.0.12": {
       "integrity": "7deabca4545bcedd07c5f69ea53acea71b8b4c67562f224e17b90d75944cb20c"
+    },
+    "@std/yaml@1.1.0": {
+      "integrity": "fc1c5c63e05c4c5eb6118355f557958035d41940d6c29d35b306ef7155d6edb0"
     }
   },
   "workspace": {
     "dependencies": [
-      "jsr:@jlarky/gha-ts@~0.2.1",
+      "jsr:@jlarky/gha-ts@~0.2.2",
       "jsr:@std/assert@1",
       "jsr:@std/yaml@^1.0.12"
     ]


### PR DESCRIPTION
gha-ts 0.2.2 bumps the \`checkout()\` helper from \`@v4\` to \`@v5\` (JLarky/gha-ts#62), moving off the deprecated Node.js 20 runtime that GitHub will remove from runners on September 16th, 2026.

## Changes
- \`deno.json\`: \`@jlarky/gha-ts\` from \`^0.2.1\` to \`^0.2.2\`
- Regenerated \`ci.generated.yml\`, \`publish.generated.yml\`, \`create-release.generated.yml\` — all checkout uses now on \`@v5\`
- Refreshed \`deno.lock\`

## Testing
- Workflows regenerated with \`deno run --allow-read --allow-write --allow-env\` on each \`*.main.ts\`
- Diff is clean: only the gha-ts version + the three checkout pins