### PR TITLE
Replace custom validation with Valibot schema validation

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -1,72 +1,36 @@
 import { join } from "node:path";
 import { parse as parseJsonc } from "@std/jsonc";
-import type { Pattern } from "./match.ts";
+import * as v from "valibot";
 
-export interface Config {
-  allow: Record<string, Pattern[]>;
-  deny?: Record<string, Pattern[]>;
-  tokens?: string[];
-  pathMap?: Record<string, string>;
-}
+const PatternSchema = v.union([
+  v.string(),
+  v.array(v.union([v.string(), v.array(v.string())])),
+]);
+
+const RuleSetSchema = v.record(v.string(), v.array(PatternSchema));
+
+const AbsoluteKeySchema = v.pipe(
+  v.string(),
+  v.startsWith("/", "must be an absolute path"),
+);
+const AbsoluteValueSchema = v.pipe(
+  v.string(),
+  v.startsWith("/", "must map to an absolute host path string"),
+);
+
+const ConfigSchema = v.object({
+  allow: RuleSetSchema,
+  deny: v.optional(RuleSetSchema),
+  tokens: v.optional(v.array(v.string())),
+  pathMap: v.optional(v.record(AbsoluteKeySchema, AbsoluteValueSchema)),
+});
+
+export type Config = v.InferOutput<typeof ConfigSchema>;
 
 function configPath(): string {
   const home = Deno.env.get("HOME");
   if (!home) throw new Error("HOME environment variable not set");
   return join(home, ".config", "lima-escape", "config.jsonc");
-}
-
-/** Validate a single pattern: string or array of (string | string[]). */
-function isValidPattern(x: unknown): x is Pattern {
-  if (typeof x === "string") return true;
-  if (!Array.isArray(x)) return false;
-  return (x as unknown[]).every((el) => {
-    if (typeof el === "string") return true;
-    if (
-      Array.isArray(el) &&
-      (el as unknown[]).every((s) => typeof s === "string")
-    ) return true;
-    return false;
-  });
-}
-
-function validateRuleSet(
-  value: unknown,
-  name: string,
-): asserts value is Record<string, Pattern[]> {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new Error(
-      `Invalid config: "${name}" must be an object mapping cwd patterns to pattern arrays`,
-    );
-  }
-  for (const [key, arr] of Object.entries(value)) {
-    if (!Array.isArray(arr) || !arr.every(isValidPattern)) {
-      throw new Error(
-        `Invalid config: "${name}" key "${key}" must map to an array of patterns (strings or arrays)`,
-      );
-    }
-  }
-}
-
-function validatePathMap(
-  value: unknown,
-): asserts value is Record<string, string> {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new Error(
-      'Invalid config: "pathMap" must be an object mapping VM path prefixes to host path prefixes',
-    );
-  }
-  for (const [vmPath, hostPath] of Object.entries(value)) {
-    if (!vmPath.startsWith("/")) {
-      throw new Error(
-        `Invalid config: "pathMap" key "${vmPath}" must be an absolute path`,
-      );
-    }
-    if (typeof hostPath !== "string" || !hostPath.startsWith("/")) {
-      throw new Error(
-        `Invalid config: "pathMap" key "${vmPath}" must map to an absolute host path string`,
-      );
-    }
-  }
 }
 
 export function loadConfig(path?: string): Config {
@@ -83,38 +47,18 @@ export function loadConfig(path?: string): Config {
     throw e;
   }
 
-  const raw = parseJsonc(text) as Record<string, unknown>;
-
-  validateRuleSet(raw.allow, "allow");
-  if (raw.deny !== undefined) {
-    validateRuleSet(raw.deny, "deny");
-  }
-  if (raw.pathMap !== undefined) {
-    validatePathMap(raw.pathMap);
-  }
-  if (raw.tokens !== undefined) {
-    if (
-      !Array.isArray(raw.tokens) ||
-      !raw.tokens.every((x: unknown) => typeof x === "string")
-    ) {
-      throw new Error('Invalid config: "tokens" must be an array of strings');
-    }
-  }
-
-  return {
-    allow: raw.allow,
-    ...(raw.deny ? { deny: raw.deny } : {}),
-    ...(raw.pathMap ? { pathMap: raw.pathMap } : {}),
-    ...(raw.tokens ? { tokens: raw.tokens } : {}),
-  };
+  return v.parse(ConfigSchema, parseJsonc(text));
 }
 
 /** Re-read just the tokens array from config (for hot-reload on each request). */
 export function loadTokens(path?: string): string[] {
   const p = path ?? configPath();
   try {
-    const raw = parseJsonc(Deno.readTextFileSync(p)) as Record<string, unknown>;
-    if (Array.isArray(raw.tokens)) return raw.tokens as string[];
+    const result = v.safeParse(
+      ConfigSchema,
+      parseJsonc(Deno.readTextFileSync(p)),
+    );
+    if (result.success) return result.output.tokens ?? [];
     return [];
   } catch {
     return [];

--- a/config.ts
+++ b/config.ts
@@ -47,7 +47,17 @@ export function loadConfig(path?: string): Config {
     throw e;
   }
 
-  return v.parse(ConfigSchema, parseJsonc(text));
+  try {
+    return v.parse(ConfigSchema, parseJsonc(text));
+  } catch (e) {
+    if (v.isValiError(e)) {
+      const issue = e.issues[0];
+      const field = issue.path?.map((seg) => String(seg.key)).join(".") ??
+        "(root)";
+      throw new Error(`Invalid config at "${field}": ${issue.message}`);
+    }
+    throw e;
+  }
 }
 
 /** Re-read just the tokens array from config (for hot-reload on each request). */

--- a/config_test.ts
+++ b/config_test.ts
@@ -7,59 +7,135 @@ function writeTempConfig(config: unknown): string {
   return path;
 }
 
-Deno.test("loadConfig: accepts valid pathMap", () => {
-  const path = writeTempConfig({
-    pathMap: {
-      "/home/jlarky.guest/work": "/Users/jlarky/work",
-    },
-    allow: { "*": ["git status"] },
-  });
-
+function withTempConfig(config: unknown, fn: (path: string) => void): void {
+  const path = writeTempConfig(config);
   try {
-    const config = loadConfig(path);
-    assertEquals(config.pathMap, {
-      "/home/jlarky.guest/work": "/Users/jlarky/work",
-    });
+    fn(path);
   } finally {
     Deno.removeSync(path);
   }
+}
+
+// --- valid configs ---
+
+Deno.test("loadConfig: accepts minimal valid config", () => {
+  withTempConfig({ allow: { "*": ["git status"] } }, (path) => {
+    const config = loadConfig(path);
+    assertEquals(config.allow, { "*": ["git status"] });
+  });
 });
 
-Deno.test("loadConfig: rejects relative pathMap keys", () => {
-  const path = writeTempConfig({
-    pathMap: {
-      "home/jlarky.guest/work": "/Users/jlarky/work",
+Deno.test("loadConfig: accepts valid pathMap", () => {
+  withTempConfig(
+    {
+      pathMap: { "/home/jlarky.guest/work": "/Users/jlarky/work" },
+      allow: { "*": ["git status"] },
     },
-    allow: { "*": ["git status"] },
-  });
+    (path) => {
+      const config = loadConfig(path);
+      assertEquals(config.pathMap, {
+        "/home/jlarky.guest/work": "/Users/jlarky/work",
+      });
+    },
+  );
+});
 
-  try {
-    assertThrows(
-      () => loadConfig(path),
-      Error,
-      "must be an absolute path",
-    );
-  } finally {
-    Deno.removeSync(path);
-  }
+Deno.test("loadConfig: accepts array-form patterns", () => {
+  withTempConfig(
+    { allow: { "*": [["git", ["status", "log"]]] } },
+    (path) => {
+      const config = loadConfig(path);
+      assertEquals(config.allow["*"], [["git", ["status", "log"]]]);
+    },
+  );
+});
+
+// --- missing / wrong-type top-level fields ---
+
+Deno.test("loadConfig: error names the field when allow is missing", () => {
+  withTempConfig({}, (path) => {
+    assertThrows(() => loadConfig(path), Error, 'at "allow"');
+  });
+});
+
+Deno.test("loadConfig: error names the field when allow is not an object", () => {
+  withTempConfig({ allow: "git status" }, (path) => {
+    assertThrows(() => loadConfig(path), Error, 'at "allow"');
+  });
+});
+
+Deno.test("loadConfig: error names the field when allow value is not an array", () => {
+  withTempConfig({ allow: { "*": "git status" } }, (path) => {
+    assertThrows(() => loadConfig(path), Error, 'at "allow.*"');
+  });
+});
+
+Deno.test("loadConfig: error names the field when deny is not an object", () => {
+  withTempConfig({ allow: { "*": ["git status"] }, deny: 42 }, (path) => {
+    assertThrows(() => loadConfig(path), Error, 'at "deny"');
+  });
+});
+
+Deno.test("loadConfig: error names the field when tokens is not an array", () => {
+  withTempConfig(
+    { allow: { "*": ["git status"] }, tokens: "abc" },
+    (path) => {
+      assertThrows(() => loadConfig(path), Error, 'at "tokens"');
+    },
+  );
+});
+
+Deno.test("loadConfig: error names the index when tokens contains a non-string", () => {
+  withTempConfig(
+    { allow: { "*": ["git status"] }, tokens: [123] },
+    (path) => {
+      assertThrows(() => loadConfig(path), Error, 'at "tokens.0"');
+    },
+  );
+});
+
+// --- pathMap validation ---
+
+Deno.test("loadConfig: rejects relative pathMap keys", () => {
+  withTempConfig(
+    {
+      pathMap: { "home/jlarky.guest/work": "/Users/jlarky/work" },
+      allow: { "*": ["git status"] },
+    },
+    (path) => {
+      assertThrows(() => loadConfig(path), Error, "must be an absolute path");
+    },
+  );
 });
 
 Deno.test("loadConfig: rejects relative pathMap values", () => {
-  const path = writeTempConfig({
-    pathMap: {
-      "/home/jlarky.guest/work": "Users/jlarky/work",
+  withTempConfig(
+    {
+      pathMap: { "/home/jlarky.guest/work": "Users/jlarky/work" },
+      allow: { "*": ["git status"] },
     },
-    allow: { "*": ["git status"] },
-  });
+    (path) => {
+      assertThrows(
+        () => loadConfig(path),
+        Error,
+        "must map to an absolute host path string",
+      );
+    },
+  );
+});
 
-  try {
-    assertThrows(
-      () => loadConfig(path),
-      Error,
-      "must map to an absolute host path string",
-    );
-
-  } finally {
-    Deno.removeSync(path);
-  }
+Deno.test("loadConfig: error includes pathMap key name for relative key", () => {
+  withTempConfig(
+    {
+      pathMap: { "home/jlarky.guest/work": "/Users/jlarky/work" },
+      allow: { "*": ["git status"] },
+    },
+    (path) => {
+      assertThrows(
+        () => loadConfig(path),
+        Error,
+        'at "pathMap.home/jlarky.guest/work"',
+      );
+    },
+  );
 });

--- a/config_test.ts
+++ b/config_test.ts
@@ -37,7 +37,7 @@ Deno.test("loadConfig: rejects relative pathMap keys", () => {
     assertThrows(
       () => loadConfig(path),
       Error,
-      '"pathMap" key "home/jlarky.guest/work" must be an absolute path',
+      "must be an absolute path",
     );
   } finally {
     Deno.removeSync(path);
@@ -58,6 +58,7 @@ Deno.test("loadConfig: rejects relative pathMap values", () => {
       Error,
       "must map to an absolute host path string",
     );
+
   } finally {
     Deno.removeSync(path);
   }

--- a/deno.json
+++ b/deno.json
@@ -22,7 +22,8 @@
     "@jlarky/gha-ts": "jsr:@jlarky/gha-ts@^0.2.2",
     "@std/assert": "jsr:@std/assert@1",
     "@std/jsonc": "jsr:@std/jsonc@^1.0.1",
-    "@std/yaml": "jsr:@std/yaml@^1.0.12"
+    "@std/yaml": "jsr:@std/yaml@^1.0.12",
+    "valibot": "npm:valibot@^1.0.0"
   },
   "test": {
     "include": ["*_test.ts"]


### PR DESCRIPTION
## Summary
Refactored config validation to use Valibot, a lightweight schema validation library, replacing custom validation logic. This improves maintainability and provides more consistent error messages.

## Key Changes
- **Replaced custom validators** with Valibot schema definitions for `Config`, `RuleSet`, and path validation
- **Improved error messages** to include field paths (e.g., `at "allow"`, `at "pathMap.home/jlarky.guest/work"`) for better debugging
- **Simplified `loadConfig()`** by delegating all validation to `v.parse()` instead of manual assertion functions
- **Updated `loadTokens()`** to use `v.safeParse()` for graceful error handling during hot-reload
- **Refactored test suite** to use a `withTempConfig()` helper function, reducing boilerplate and improving test organization
- **Reorganized tests** into logical groups: valid configs, field validation, and pathMap validation
- **Added new test cases** for edge cases like array-form patterns and specific field error messages

## Implementation Details
- Config type is now derived from the Valibot schema using `v.InferOutput<typeof ConfigSchema>`
- Path validation uses Valibot pipes with custom error messages for absolute path requirements
- Error handling extracts the field path from Valibot's issue structure for user-friendly messages
- Tests now follow a consistent pattern with the `withTempConfig()` helper, making them more readable and maintainable

https://claude.ai/code/session_01JVvjRHASzw8paCDdb7dvs9