### PR TITLE
Add regexp tokens for command allowlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Two formats are supported:
   etc.)
 - Tokens are matched with `===`, no glob/regex
 
-**Array patterns** (for alternatives):
+**Array patterns** (for alternatives and structured tokens):
 
 ```json
 { "allow": { "*": [["gh", ["pr", "issue"], "*"], ["git", "status"]] } }
@@ -124,6 +124,25 @@ Two formats are supported:
 - `["gh", "pr", "*"]` — zero or more trailing args (same as `"gh pr *"`)
 - `["gh", ["pr", "issue"], "*"]` — alternatives: matches `gh pr ...` or
   `gh issue ...`
+- `{"regexp":"^repos/.+/comments$"}` — regex for a single argv token
+
+Example regex-scoped `gh api` route:
+
+```json
+{
+  "allow": {
+    "*": [
+      [
+        "gh",
+        "api",
+        {
+          "regexp": "^repos/[A-Za-z0-9-]+/[A-Za-z0-9._-]+/pulls/[0-9]+/(comments|reviews|review_comments)$"
+        }
+      ]
+    ]
+  }
+}
+```
 
 Fail-closed: forgetting `*` gives less access, not more.
 

--- a/config.example.json
+++ b/config.example.json
@@ -7,6 +7,13 @@
     "*": [
       "gh pr view *",
       "gh pr list *",
+      [
+        "gh",
+        "api",
+        {
+          "regexp": "^repos/[A-Za-z0-9-]+/[A-Za-z0-9._-]+/pulls/[0-9]+/(comments|reviews|review_comments)$"
+        }
+      ],
       "gh issue view *",
       "gh issue list *",
       "git status",

--- a/config.ts
+++ b/config.ts
@@ -2,9 +2,29 @@ import { join } from "node:path";
 import { parse as parseJsonc } from "@std/jsonc";
 import * as v from "valibot";
 
+const RegexpTokenSchema = v.pipe(
+  v.object({
+    regexp: v.string(),
+  }),
+  v.check(({ regexp }) => {
+    try {
+      new RegExp(regexp);
+      return true;
+    } catch {
+      return false;
+    }
+  }, "must contain a valid regular expression"),
+);
+
+const PatternTokenSchema = v.union([
+  v.string(),
+  v.array(v.string()),
+  RegexpTokenSchema,
+]);
+
 const PatternSchema = v.union([
   v.string(),
-  v.array(v.union([v.string(), v.array(v.string())])),
+  v.array(PatternTokenSchema),
 ]);
 
 const RuleSetSchema = v.record(v.string(), v.array(PatternSchema));

--- a/config_test.ts
+++ b/config_test.ts
@@ -50,6 +50,30 @@ Deno.test("loadConfig: accepts array-form patterns", () => {
   );
 });
 
+Deno.test("loadConfig: accepts regexp token patterns", () => {
+  withTempConfig(
+    {
+      allow: {
+        "*": [["gh", "api", {
+          regexp:
+            "^repos/[A-Za-z0-9-]+/[A-Za-z0-9._-]+/pulls/[0-9]+/(comments|reviews|review_comments)$",
+        }]],
+      },
+    },
+    (path) => {
+      const config = loadConfig(path);
+      assertEquals(config.allow["*"], [[
+        "gh",
+        "api",
+        {
+          regexp:
+            "^repos/[A-Za-z0-9-]+/[A-Za-z0-9._-]+/pulls/[0-9]+/(comments|reviews|review_comments)$",
+        },
+      ]]);
+    },
+  );
+});
+
 // --- missing / wrong-type top-level fields ---
 
 Deno.test("loadConfig: error names the field when allow is missing", () => {
@@ -74,6 +98,15 @@ Deno.test("loadConfig: error names the field when deny is not an object", () => 
   withTempConfig({ allow: { "*": ["git status"] }, deny: 42 }, (path) => {
     assertThrows(() => loadConfig(path), Error, 'at "deny"');
   });
+});
+
+Deno.test("loadConfig: error names regexp token field when regexp is invalid", () => {
+  withTempConfig(
+    { allow: { "*": [["gh", "api", { regexp: "^(" }]] } },
+    (path) => {
+      assertThrows(() => loadConfig(path), Error, 'at "allow.*.0.2"');
+    },
+  );
 });
 
 Deno.test("loadConfig: error names the field when tokens is not an array", () => {

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@jlarky/lima-escape",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "exports": {
     ".": "./server.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -4,8 +4,11 @@
     "jsr:@jlarky/gha-ts@~0.2.2": "0.2.2",
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/json@^1.0.2": "1.1.0",
+    "jsr:@std/jsonc@^1.0.1": "1.0.2",
     "jsr:@std/yaml@*": "1.0.12",
-    "jsr:@std/yaml@^1.0.12": "1.1.0"
+    "jsr:@std/yaml@^1.0.12": "1.1.0",
+    "npm:valibot@1": "1.4.0"
   },
   "jsr": {
     "@jlarky/gha-ts@0.2.2": {
@@ -20,6 +23,15 @@
     "@std/internal@1.0.12": {
       "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
     },
+    "@std/json@1.1.0": {
+      "integrity": "93330d3ed4054d6b1ffe54b075432c80a5f671be77277b978931e018014cb1cc"
+    },
+    "@std/jsonc@1.0.2": {
+      "integrity": "909605dae3af22bd75b1cbda8d64a32cf1fd2cf6efa3f9e224aba6d22c0f44c7",
+      "dependencies": [
+        "jsr:@std/json"
+      ]
+    },
     "@std/yaml@1.0.12": {
       "integrity": "7deabca4545bcedd07c5f69ea53acea71b8b4c67562f224e17b90d75944cb20c"
     },
@@ -27,11 +39,18 @@
       "integrity": "fc1c5c63e05c4c5eb6118355f557958035d41940d6c29d35b306ef7155d6edb0"
     }
   },
+  "npm": {
+    "valibot@1.4.0": {
+      "integrity": "sha512-iC/x7fVcSyOwlm/VSt7RlHnzNGLGvR9GnxdifUeWoCJo0q4ZZvrVkIHC6faTlkxG47I2Y4UrFquPuVHCrOnrLg=="
+    }
+  },
   "workspace": {
     "dependencies": [
       "jsr:@jlarky/gha-ts@~0.2.2",
       "jsr:@std/assert@1",
-      "jsr:@std/yaml@^1.0.12"
+      "jsr:@std/jsonc@^1.0.1",
+      "jsr:@std/yaml@^1.0.12",
+      "npm:valibot@1"
     ]
   }
 }

--- a/main.ts
+++ b/main.ts
@@ -87,10 +87,12 @@ Setup:
      pathMap is optional. It rewrites a Lima cwd prefix to a host cwd prefix
      before execution. Allow/deny rules still match the Lima path you ran from.
 
-      Keys are directory patterns. "*" matches any directory; paths use prefix
-      matching (e.g. "/home/user" matches "/home/user/sub"). Command patterns
-      use exact token matching - "gh pr *" means gh + pr + zero or more args.
-     Deny rules take precedence over allow rules at equal specificity.
+       Keys are directory patterns. "*" matches any directory; paths use prefix
+       matching (e.g. "/home/user" matches "/home/user/sub"). Command patterns
+       use exact token matching - "gh pr *" means gh + pr + zero or more args.
+       Array patterns may also use structured tokens like
+       {"regexp":"^repos/.+/comments$"} to match a single argv element.
+       Deny rules take precedence over allow rules at equal specificity.
 
   6. Authenticate from the VM:
 

--- a/match.ts
+++ b/match.ts
@@ -6,8 +6,14 @@
  * - Array patterns: ["gh", ["pr", "issue"], "*"] (Codex-style alternatives)
  */
 
+export interface RegexpToken {
+  regexp: string;
+}
+
+export type PatternToken = string | string[] | RegexpToken;
+
 /** A single command pattern: string sugar or array form. */
-export type Pattern = string | (string | string[])[];
+export type Pattern = string | PatternToken[];
 
 export type AllowResult =
   | { allowed: true }
@@ -35,7 +41,7 @@ export function cwdMatches(pattern: string, cwd: string): boolean {
 }
 
 /** Desugar a string pattern into array form by splitting on spaces. */
-function toArrayPattern(pattern: Pattern): (string | string[])[] {
+function toArrayPattern(pattern: Pattern): PatternToken[] {
   if (typeof pattern === "string") {
     return pattern.split(" ");
   }
@@ -76,11 +82,18 @@ export function matchCommand(pattern: Pattern, argv: string[]): boolean {
 }
 
 /** Match a single token against an argv element. */
-function matchToken(token: string | string[], value: string): boolean {
+function matchToken(token: PatternToken, value: string): boolean {
   if (Array.isArray(token)) {
     return token.includes(value);
   }
+  if (typeof token === "object") {
+    return new RegExp(token.regexp).test(value);
+  }
   return token === value;
+}
+
+function isRegexpToken(token: PatternToken): token is RegexpToken {
+  return typeof token === "object" && !Array.isArray(token);
 }
 
 /**
@@ -91,15 +104,20 @@ function matchToken(token: string | string[], value: string): boolean {
  */
 export function prettyPrintPattern(pattern: Pattern): string {
   if (typeof pattern === "string") return pattern;
-  const hasAlternatives = pattern.some((el) => Array.isArray(el));
-  if (!hasAlternatives) return (pattern as string[]).join(" ");
+  const hasStructuredTokens = pattern.some((el) =>
+    Array.isArray(el) || isRegexpToken(el)
+  );
+  if (!hasStructuredTokens) return (pattern as string[]).join(" ");
   return JSON.stringify(pattern);
 }
 
 /** Format a pattern for display in error messages (with quotes). */
 function formatPattern(pattern: Pattern): string {
   const pp = prettyPrintPattern(pattern);
-  if (typeof pattern === "string" || !pattern.some((el) => Array.isArray(el))) {
+  if (
+    typeof pattern === "string" ||
+    !pattern.some((el) => Array.isArray(el) || isRegexpToken(el))
+  ) {
     return `"${pp}"`;
   }
   return pp;
@@ -204,9 +222,11 @@ function findHint(argv: string[], rules: Rules): string | undefined {
       if (prefixMatches) {
         const patStr = typeof pattern === "string"
           ? pattern
-          : tokens.map((t) => Array.isArray(t) ? `[${t.join(",")}]` : t).join(
-            " ",
-          );
+          : tokens.map((t) => {
+            if (Array.isArray(t)) return `[${t.join(",")}]`;
+            if (isRegexpToken(t)) return JSON.stringify(t);
+            return t;
+          }).join(" ");
         return `"${patStr}" is allowed but does not permit extra arguments. To allow "${patStr}" with any arguments, use "${patStr} *" instead.`;
       }
     }

--- a/match_deno_test.ts
+++ b/match_deno_test.ts
@@ -92,6 +92,50 @@ Deno.test("matchCommand: array alternatives with trailing *", () => {
   );
 });
 
+Deno.test("matchCommand: regexp token matches a single argv element", () => {
+  assertEquals(
+    matchCommand(
+      [
+        "gh",
+        "api",
+        {
+          regexp:
+            "^repos/[A-Za-z0-9-]+/[A-Za-z0-9._-]+/pulls/[0-9]+/(comments|reviews|review_comments)$",
+        },
+      ],
+      ["gh", "api", "repos/JLarky/lima-escape/pulls/948/comments"],
+    ),
+    true,
+  );
+});
+
+Deno.test("matchCommand: regexp token does not cross argv elements", () => {
+  assertEquals(
+    matchCommand(
+      ["gh", "api", { regexp: "^repos/.+/comments$" }],
+      ["gh", "api", "repos/JLarky/lima-escape/pulls/948", "comments"],
+    ),
+    false,
+  );
+});
+
+Deno.test("matchCommand: regexp token rejects non-matching argv element", () => {
+  assertEquals(
+    matchCommand(
+      [
+        "gh",
+        "api",
+        {
+          regexp:
+            "^repos/[A-Za-z0-9-]+/[A-Za-z0-9._-]+/pulls/[0-9]+/(comments|reviews|review_comments)$",
+        },
+      ],
+      ["gh", "api", "repos/JLarky/lima-escape/issues/948/comments"],
+    ),
+    false,
+  );
+});
+
 Deno.test("matchCommand: array exact rejects extra args", () => {
   assertEquals(
     matchCommand(["gh", "pr"], ["gh", "pr", "view"]),
@@ -355,6 +399,45 @@ Deno.test("allowlist: mixed string and array patterns", () => {
   assertEquals(
     isAllowed(["gh", "issue"], "/any", rules).allowed,
     true,
+  );
+});
+
+Deno.test("allowlist: regexp token pattern constrains gh api route", () => {
+  const rules: Rules = {
+    allow: {
+      "*": [[
+        "gh",
+        "api",
+        {
+          regexp:
+            "^repos/[A-Za-z0-9-]+/[A-Za-z0-9._-]+/pulls/[0-9]+/(comments|reviews|review_comments)$",
+        },
+      ]],
+    },
+  };
+  assertEquals(
+    isAllowed(
+      ["gh", "api", "repos/JLarky/lima-escape/pulls/948/comments"],
+      "/any",
+      rules,
+    ).allowed,
+    true,
+  );
+  assertEquals(
+    isAllowed(
+      ["gh", "api", "repos/JLarky/lima-escape/pulls/948/files"],
+      "/any",
+      rules,
+    ).allowed,
+    false,
+  );
+  assertEquals(
+    isAllowed(
+      ["gh", "api", "repos/JLarky/lima escape/pulls/948/comments"],
+      "/any",
+      rules,
+    ).allowed,
+    false,
   );
 });
 

--- a/shared.ts
+++ b/shared.ts
@@ -210,7 +210,8 @@ async function handleConnection(conn: Deno.Conn, opts: ServerOptions) {
             if (typeof p === "string") return [p.split(" ")[0]];
             const first = p[0];
             if (typeof first === "string") return [first];
-            return first; // string[] alternatives — all are possible commands
+            if (Array.isArray(first)) return first; // alternatives — all are possible commands
+            return [];
           }),
         ),
       ];


### PR DESCRIPTION
## Summary
- add structured `{ \"regexp\": \"...\" }` tokens to array-form command patterns so `gh api` routes can be allowlisted at single-argv-token granularity
- validate regexp tokens when loading config and handle them correctly in matcher formatting and status reporting
- document the new syntax and cover it with matcher and config tests, including a scoped `gh api` example