### PR TITLE
Improve denied command cwd output

### DIFF
--- a/integration_test.ts
+++ b/integration_test.ts
@@ -452,16 +452,12 @@ Deno.test("getCwdStatus: reports rejected current cwd", async () => {
 
 Deno.test("formatCwdContext: includes host cwd when path mapped", () => {
   assertEquals(
-    formatCwdContext(
-      "/home/jlarky.guest/work/project",
-      "/home/jlarky.guest/work/project",
-      "/Users/jlarky/work/project",
-    ),
+    formatCwdContext("A", "B", "C"),
     [
       "cwd:",
-      "  requested: /home/jlarky.guest/work/project",
-      "  rules cwd: /home/jlarky.guest/work/project",
-      "  host cwd: /Users/jlarky/work/project",
+      "  requested: A",
+      "  rules cwd: B",
+      "  host cwd: C",
     ].join("\n"),
   );
 });

--- a/integration_test.ts
+++ b/integration_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import {
+  formatCwdContext,
   getCwdStatus,
   MAX_OUTPUT_SIZE,
   resolveRequestCwd,
@@ -447,4 +448,20 @@ Deno.test("getCwdStatus: reports rejected current cwd", async () => {
   assertEquals(typeof status.error, "string");
   assertEquals(status.matchCwd, undefined);
   assertEquals(status.executionCwd, undefined);
+});
+
+Deno.test("formatCwdContext: includes host cwd when path mapped", () => {
+  assertEquals(
+    formatCwdContext(
+      "/home/jlarky.guest/work/project",
+      "/home/jlarky.guest/work/project",
+      "/Users/jlarky/work/project",
+    ),
+    [
+      "cwd:",
+      "  requested: /home/jlarky.guest/work/project",
+      "  rules cwd: /home/jlarky.guest/work/project",
+      "  host cwd: /Users/jlarky/work/project",
+    ].join("\n"),
+  );
 });

--- a/match.ts
+++ b/match.ts
@@ -158,7 +158,9 @@ export function isAllowed(
     const hint = findHint(argv, rules);
     return {
       allowed: false,
-      reason: `"${argv.join(" ")}" does not match any allowed pattern`,
+      reason: `"${
+        argv.join(" ")
+      }" does not match any allowed pattern for cwd "${cwd}"`,
       ...(hint ? { hint } : {}),
     };
   }

--- a/match_deno_test.ts
+++ b/match_deno_test.ts
@@ -196,9 +196,11 @@ Deno.test("cwd: allows git push in subdirectory (prefix match)", () => {
 });
 
 Deno.test("cwd: blocks git push in other dir", () => {
+  const result = isAllowed(["git", "push", "origin"], "/home/other", CWD_RULES);
+  assertEquals(result.allowed, false);
   assertEquals(
-    isAllowed(["git", "push", "origin"], "/home/other", CWD_RULES).allowed,
-    false,
+    result.allowed === false && result.reason.includes('cwd "/home/other"'),
+    true,
   );
 });
 

--- a/shared.ts
+++ b/shared.ts
@@ -165,6 +165,22 @@ export async function getCwdStatus(
   };
 }
 
+export function formatCwdContext(
+  requestedCwd: string,
+  rulesCwd: string,
+  hostCwd: string,
+): string {
+  const lines = [
+    "cwd:",
+    `  requested: ${requestedCwd}`,
+    `  rules cwd: ${rulesCwd}`,
+  ];
+  if (hostCwd !== rulesCwd) {
+    lines.push(`  host cwd: ${hostCwd}`);
+  }
+  return lines.join("\n");
+}
+
 async function executeCommand(argv: string[], cwd: string): Promise<Response> {
   const command = new Deno.Command(argv[0], { args: argv.slice(1), cwd });
   const { code, stdout, stderr } = await command.output();
@@ -269,8 +285,9 @@ async function handleConnection(conn: Deno.Conn, opts: ServerOptions) {
             res = {
               code: 1,
               stdout: "",
-              stderr:
-                `denied: ${result.reason}${hint}\n\nRun \`lima-escape --help\` for setup instructions or \`lima-escape --status\` to see currently allowed patterns.`,
+              stderr: `denied: ${result.reason}${hint}\n\n${
+                formatCwdContext(req.cwd, matchCwd, executionCwd)
+              }\n\nRun \`lima-escape --help\` for setup instructions or \`lima-escape --status\` to see currently allowed patterns.`,
               error: "denied",
             };
             console.log("denied:", cmd, "-", result.reason);


### PR DESCRIPTION
## Summary
- include requested, rules, and host cwd context in denied command output
- add test coverage for mapped cwd formatting

## Test
- mise exec deno@2.7.12 -- deno test -A
- mise exec deno@2.7.12 -- deno fmt --check