### PR TITLE
Update README config filename references

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ lima-escape --help     # full setup reference
 
 ## Security
 
-1. **Token auth**: clients must present a token from `config.jsonc` — without it,
-   exec requests are rejected
+1. **Token auth**: clients must present a token from `config.jsonc` — without
+   it, exec requests are rejected
 2. **Allowlist**: only commands matching token-based patterns in config execute
 3. **No shell**: always `Deno.Command` with argv array, never `sh -c`
 4. **Argv-in, argv-out**: client sends pre-split argv from the OS, server

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ print the token and instructions. Copy the token for the next step.
 
 ### 3. Create a config (on host)
 
-Create `~/.config/lima-escape/config.json` on your **host** with allow/deny
+Create `~/.config/lima-escape/config.jsonc` on your **host** with allow/deny
 rules scoped by directory:
 
 ```json
@@ -195,7 +195,7 @@ lima-escape --help     # full setup reference
 
 ## Security
 
-1. **Token auth**: clients must present a token from `config.json` — without it,
+1. **Token auth**: clients must present a token from `config.jsonc` — without it,
    exec requests are rejected
 2. **Allowlist**: only commands matching token-based patterns in config execute
 3. **No shell**: always `Deno.Command` with argv array, never `sh -c`


### PR DESCRIPTION
## Summary
- update remaining README references from config.json to config.jsonc
- preserves the useful leftover documentation cleanup from the now-closed #19

## Context
#19 was closed as superseded by #27, which already implemented JSONC config support. This PR keeps the small remaining README correction without merging the stale branch.

## Test
- Not run; documentation-only change.