### PR TITLE
Add gh pr diff to allowlist examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ rules scoped by directory:
   "allow": {
     "*": [
       "say *",
-      ["gh", "pr", ["list", "view", "checks"], "*"],
+      ["gh", "pr", ["list", "view", "checks", "diff"], "*"],
       ["gh", "issue", ["create", "edit", "list", "view"], "*"],
       "git status",
       "git log *",
@@ -106,7 +106,7 @@ Two formats are supported:
 **String patterns** (sugar for simple cases):
 
 ```json
-{ "allow": { "*": ["gh pr", "gh pr *", "git status"] } }
+{ "allow": { "*": ["gh pr", "gh pr view *", "gh pr diff *", "git status"] } }
 ```
 
 - `"gh pr"` — exact match, only `gh pr` with no trailing args

--- a/config.example.json
+++ b/config.example.json
@@ -7,6 +7,7 @@
     "*": [
       "gh pr view *",
       "gh pr list *",
+      "gh pr diff *",
       [
         "gh",
         "api",

--- a/config.ts
+++ b/config.ts
@@ -61,7 +61,7 @@ export function loadConfig(path?: string): Config {
   } catch (e) {
     if (e instanceof Deno.errors.NotFound) {
       throw new Error(
-        `Config not found at ${p}\nCreate it with an "allow" object, e.g.:\n  { "allow": { "*": ["gh pr view *", "git status"] } }`,
+        `Config not found at ${p}\nCreate it with an "allow" object, e.g.:\n  { "allow": { "*": ["gh pr view *", "gh pr diff *", "git status"] } }`,
       );
     }
     throw e;

--- a/main.ts
+++ b/main.ts
@@ -80,7 +80,7 @@ Setup:
        "pathMap": {
          "/home/jlarky.guest/work": "/Users/jlarky/work"
        },
-       "allow": { "*": ["gh pr view *", "git status"] },
+       "allow": { "*": ["gh pr view *", "gh pr diff *", "git status"] },
        "deny": { "/sensitive": ["git *"] }
      }
 


### PR DESCRIPTION
## Summary
- add gh pr diff * to example allowlists
- include gh pr diff in README, setup help, missing-config hint, and example config

## Test
- mise exec deno@2.7.12 -- deno fmt --check
- mise exec deno@2.7.12 -- deno test -A