### PR TITLE
fix: --status shows config as-is (no lossy pretty-print)

### DIFF
--- a/config_test.ts
+++ b/config_test.ts
@@ -1,5 +1,8 @@
 import { assertEquals, assertThrows } from "@std/assert";
 import { loadConfig } from "./config.ts";
+import { formatStatusConfigSection } from "./main.ts";
+import type { Pattern } from "./match.ts";
+import { statusConfigFromOptions, type StatusInfo } from "./shared.ts";
 
 function writeTempConfig(config: unknown): string {
   const path = Deno.makeTempFileSync({ suffix: ".json" });
@@ -171,4 +174,96 @@ Deno.test("loadConfig: error includes pathMap key name for relative key", () => 
       );
     },
   );
+});
+
+// --- status config snapshot (public, no secrets) ---
+
+const REGEXP_PATTERN: Pattern = [
+  "gh",
+  "api",
+  {
+    regexp:
+      "^repos/[A-Za-z0-9-]+/[A-Za-z0-9._-]+/pulls/[0-9]+/(comments|reviews|review_comments)$",
+  },
+];
+
+Deno.test("statusConfigFromOptions: returns sanitized config without inventing fields", () => {
+  const config = statusConfigFromOptions({
+    allow: { "*": ["git status"] },
+    deny: { "/sensitive": ["git *"] },
+    pathMap: { "/vm": "/host" },
+  });
+  assertEquals(config, {
+    allow: { "*": ["git status"] },
+    deny: { "/sensitive": ["git *"] },
+    pathMap: { "/vm": "/host" },
+  });
+  assertEquals("tokens" in config, false);
+});
+
+Deno.test("statusConfigFromOptions: prefers explicit config and never leaks tokens", () => {
+  const secret = "super-secret-token-value";
+  const full = {
+    tokens: [secret],
+    allow: { "*": [REGEXP_PATTERN] },
+    deny: { "*": ["git push -f"] },
+  };
+  // Mirror server.ts: strip tokens before exposing via status.
+  const { tokens: _tokens, ...publicConfig } = full;
+  const config = statusConfigFromOptions({
+    allow: full.allow,
+    deny: full.deny,
+    config: publicConfig,
+  });
+  assertEquals(config.allow, full.allow);
+  assertEquals(config.deny, full.deny);
+  assertEquals("tokens" in config, false);
+  assertEquals(JSON.stringify(config).includes(secret), false);
+});
+
+Deno.test("statusConfigFromOptions: preserves regexp tokens verbatim", () => {
+  const config = statusConfigFromOptions({
+    allow: { "*": [REGEXP_PATTERN] },
+  });
+  assertEquals(config.allow["*"][0], REGEXP_PATTERN);
+  assertEquals(
+    JSON.stringify(config.allow["*"][0]),
+    JSON.stringify(REGEXP_PATTERN),
+  );
+});
+
+Deno.test("formatStatusConfigSection: prints config JSON verbatim when present", () => {
+  const status: StatusInfo = {
+    allow: { "*": [REGEXP_PATTERN] },
+    config: { allow: { "*": [REGEXP_PATTERN] } },
+    allowRun: { gh: "granted" },
+  };
+  const out = formatStatusConfigSection(status);
+  assertEquals(out.startsWith("Config:\n"), true);
+  assertEquals(
+    out.includes(
+      '"regexp": "^repos/[A-Za-z0-9-]+/[A-Za-z0-9._-]+/pulls/[0-9]+/(comments|reviews|review_comments)$"',
+    ),
+    true,
+  );
+  assertEquals(out.includes("[object Object]"), false);
+  assertEquals(out.includes("Allowed patterns:"), false);
+});
+
+Deno.test("formatStatusConfigSection: falls back to pretty-print when config missing", () => {
+  const status: StatusInfo = {
+    allow: { "*": ["git status", REGEXP_PATTERN] },
+    deny: { "/sensitive": ["git *"] },
+    pathMap: { "/vm": "/host" },
+    allowRun: { git: "granted" },
+  };
+  const out = formatStatusConfigSection(status);
+  assertEquals(out.includes("Allowed patterns:"), true);
+  assertEquals(out.includes("Denied patterns:"), true);
+  assertEquals(out.includes("Path mappings:"), true);
+  assertEquals(out.includes("git status"), true);
+  assertEquals(out.includes("/vm -> /host"), true);
+  // Fallback still JSON-stringifies structured patterns (no [object Object]).
+  assertEquals(out.includes(JSON.stringify(REGEXP_PATTERN)), true);
+  assertEquals(out.includes("Config:"), false);
 });

--- a/config_test.ts
+++ b/config_test.ts
@@ -2,7 +2,11 @@ import { assertEquals, assertThrows } from "@std/assert";
 import { loadConfig } from "./config.ts";
 import { formatStatusConfigSection } from "./main.ts";
 import type { Pattern } from "./match.ts";
-import { statusConfigFromOptions, type StatusInfo } from "./shared.ts";
+import {
+  type StatusConfig,
+  statusConfigFromOptions,
+  type StatusInfo,
+} from "./shared.ts";
 
 function writeTempConfig(config: unknown): string {
   const path = Deno.makeTempFileSync({ suffix: ".json" });
@@ -203,22 +207,26 @@ Deno.test("statusConfigFromOptions: returns sanitized config without inventing f
 
 Deno.test("statusConfigFromOptions: prefers explicit config and never leaks tokens", () => {
   const secret = "super-secret-token-value";
-  const full = {
+  // Runtime object may carry tokens despite StatusConfig (TS-only) typing.
+  const tainted = {
     tokens: [secret],
     allow: { "*": [REGEXP_PATTERN] },
     deny: { "*": ["git push -f"] },
-  };
-  // Mirror server.ts: strip tokens before exposing via status.
-  const { tokens: _tokens, ...publicConfig } = full;
+    pathMap: { "/vm": "/host" },
+  } as unknown as StatusConfig;
   const config = statusConfigFromOptions({
-    allow: full.allow,
-    deny: full.deny,
-    config: publicConfig,
+    allow: { "*": ["git status"] },
+    config: tainted,
   });
-  assertEquals(config.allow, full.allow);
-  assertEquals(config.deny, full.deny);
+  assertEquals(config, {
+    allow: { "*": [REGEXP_PATTERN] },
+    deny: { "*": ["git push -f"] },
+    pathMap: { "/vm": "/host" },
+  });
   assertEquals("tokens" in config, false);
-  assertEquals(JSON.stringify(config).includes(secret), false);
+  const json = JSON.stringify(config);
+  assertEquals(json.includes("tokens"), false);
+  assertEquals(json.includes(secret), false);
 });
 
 Deno.test("statusConfigFromOptions: preserves regexp tokens verbatim", () => {

--- a/main.ts
+++ b/main.ts
@@ -2,6 +2,36 @@
 import { prettyPrintPattern } from "./match.ts";
 import { DEFAULT_PORT, startClient, type StatusInfo } from "./shared.ts";
 
+/** Format the allow/deny section of --status output. */
+export function formatStatusConfigSection(status: StatusInfo): string {
+  if (status.config) {
+    return "Config:\n" + JSON.stringify(status.config, null, 2);
+  }
+  const lines: string[] = ["Allowed patterns:"];
+  for (const [cwdPattern, patterns] of Object.entries(status.allow)) {
+    lines.push(`  [cwd: ${cwdPattern}]`);
+    for (const pattern of patterns) {
+      lines.push(`    ${prettyPrintPattern(pattern)}`);
+    }
+  }
+  if (status.deny) {
+    lines.push("", "Denied patterns:");
+    for (const [cwdPattern, patterns] of Object.entries(status.deny)) {
+      lines.push(`  [cwd: ${cwdPattern}]`);
+      for (const pattern of patterns) {
+        lines.push(`    ${prettyPrintPattern(pattern)}`);
+      }
+    }
+  }
+  if (status.pathMap) {
+    lines.push("", "Path mappings:");
+    for (const [vmPath, hostPath] of Object.entries(status.pathMap)) {
+      lines.push(`  ${vmPath} -> ${hostPath}`);
+    }
+  }
+  return lines.join("\n");
+}
+
 function tokenPath(): string {
   const home = Deno.env.get("HOME");
   if (!home) throw new Error("HOME not set");
@@ -138,28 +168,7 @@ Learn more at:
       // Old server that doesn't support --status
     }
     if (status?.allow) {
-      console.log("Allowed patterns:");
-      for (const [cwdPattern, patterns] of Object.entries(status.allow)) {
-        console.log(`  [cwd: ${cwdPattern}]`);
-        for (const pattern of patterns) {
-          console.log(`    ${prettyPrintPattern(pattern)}`);
-        }
-      }
-      if (status.deny) {
-        console.log("\nDenied patterns:");
-        for (const [cwdPattern, patterns] of Object.entries(status.deny)) {
-          console.log(`  [cwd: ${cwdPattern}]`);
-          for (const pattern of patterns) {
-            console.log(`    ${prettyPrintPattern(pattern)}`);
-          }
-        }
-      }
-      if (status.pathMap) {
-        console.log("\nPath mappings:");
-        for (const [vmPath, hostPath] of Object.entries(status.pathMap)) {
-          console.log(`  ${vmPath} -> ${hostPath}`);
-        }
-      }
+      console.log(formatStatusConfigSection(status));
       if (status.cwdStatus) {
         console.log("\nCurrent cwd:");
         console.log(`  requested  ${status.cwdStatus.requested}`);
@@ -183,7 +192,7 @@ Learn more at:
           cmds.join(",")
         } ${serverUrl}`;
       const configJson = JSON.stringify(
-        {
+        status.config ?? {
           ...(status.pathMap ? { pathMap: status.pathMap } : {}),
           allow: status.allow,
           ...(status.deny ? { deny: status.deny } : {}),

--- a/server.ts
+++ b/server.ts
@@ -25,10 +25,14 @@ function checkToken(token: string): boolean {
   return loadTokens().includes(token);
 }
 
+// Strip secrets before exposing config via --status.
+const { tokens: _tokens, ...publicConfig } = config;
+
 await startServer({
   allow: config.allow,
   deny: config.deny,
   pathMap: config.pathMap,
+  config: publicConfig,
   isAllowed,
   checkToken,
 });

--- a/shared.ts
+++ b/shared.ts
@@ -59,18 +59,21 @@ export interface ServerOptions {
   checkToken?: (token: string) => boolean;
 }
 
-/** Build the public config snapshot included in status responses. */
+/** Build the public config snapshot included in status responses.
+ * Always whitelists fields — never returns/spreads config wholesale
+ * (StatusConfig is TypeScript-only; a runtime object may still carry tokens).
+ */
 export function statusConfigFromOptions(opts: {
   allow: Record<string, Pattern[]>;
   deny?: Record<string, Pattern[]>;
   pathMap?: Record<string, string>;
   config?: StatusConfig;
 }): StatusConfig {
-  if (opts.config) return opts.config;
+  const src = opts.config ?? opts;
   return {
-    allow: opts.allow,
-    ...(opts.deny ? { deny: opts.deny } : {}),
-    ...(opts.pathMap ? { pathMap: opts.pathMap } : {}),
+    allow: src.allow,
+    ...(src.deny ? { deny: src.deny } : {}),
+    ...(src.pathMap ? { pathMap: src.pathMap } : {}),
   };
 }
 

--- a/shared.ts
+++ b/shared.ts
@@ -13,9 +13,18 @@ export interface Request {
   token?: string;
 }
 
+/** Public config snapshot for --status (never includes tokens). */
+export interface StatusConfig {
+  allow: Record<string, Pattern[]>;
+  deny?: Record<string, Pattern[]>;
+  pathMap?: Record<string, string>;
+}
+
 export interface StatusInfo {
   allow: Record<string, Pattern[]>;
   deny?: Record<string, Pattern[]>;
+  /** Raw allow/deny/pathMap as loaded — preferred by new clients for verbatim display. */
+  config?: StatusConfig;
   pathMap?: Record<string, string>;
   cwdStatus?: CwdStatus;
   allowRun: Record<string, string>;
@@ -43,9 +52,26 @@ export interface ServerOptions {
   allow: Record<string, Pattern[]>;
   deny?: Record<string, Pattern[]>;
   pathMap?: Record<string, string>;
+  /** Sanitized config for status (must not include tokens). */
+  config?: StatusConfig;
   isAllowed: (argv: string[], cwd: string, rules: Rules) => AllowResult;
   port?: number;
   checkToken?: (token: string) => boolean;
+}
+
+/** Build the public config snapshot included in status responses. */
+export function statusConfigFromOptions(opts: {
+  allow: Record<string, Pattern[]>;
+  deny?: Record<string, Pattern[]>;
+  pathMap?: Record<string, string>;
+  config?: StatusConfig;
+}): StatusConfig {
+  if (opts.config) return opts.config;
+  return {
+    allow: opts.allow,
+    ...(opts.deny ? { deny: opts.deny } : {}),
+    ...(opts.pathMap ? { pathMap: opts.pathMap } : {}),
+  };
 }
 
 function pathSpecificity(path: string): number {
@@ -248,6 +274,7 @@ async function handleConnection(conn: Deno.Conn, opts: ServerOptions) {
       const status: StatusInfo = {
         allow: opts.allow,
         ...(opts.deny ? { deny: opts.deny } : {}),
+        config: statusConfigFromOptions(opts),
         ...(opts.pathMap ? { pathMap: opts.pathMap } : {}),
         cwdStatus: await getCwdStatus(req.cwd, opts.pathMap),
         allowRun,


### PR DESCRIPTION
## Summary
- Status responses now include a sanitized `config` snapshot (allow/deny/pathMap, never `tokens`) so clients can display the loaded JSON as written.
- `lima-escape --status` prints that config with 2-space `JSON.stringify` instead of lossy `prettyPrintPattern` (which turned regexp tokens into opaque or re-serialized forms).
- Older servers without `config` keep the previous pretty-print fallback.

## Test plan
- [x] `deno test -A` (payload shape: no token leak, regexp verbatim, client fallback)
- [x] Local server + client: `--status` shows `{"regexp":…}` as-is; secret token absent from output
- [ ] Spot-check against an older server build (missing `config`) still pretty-prints


Made with [Cursor](https://cursor.com)